### PR TITLE
Stop running unit tests twice in build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,6 @@ jobs:
         java-version: '17'
         cache: maven
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B package --file pom.xml -DskipTests
     - name: Run Tests with Maven
       run: mvn -B verify --file pom.xml


### PR DESCRIPTION
We currently run the unit tests in both the `Build with Maven` step and the `Run Tests with Maven` step. With this change we will no longer run the unit tests during the `Build with Maven` step.