### PR TITLE
Automatically deploy dmn files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,9 +10,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: zeebe-io/zbctl-action@v0.0.7
+        name: Deploy BPMN
         with:
           version: '8.0.4'
-          command: 'deploy resource src/main/resources/*.{bpmn|dmn}'
+          command: 'deploy resource src/main/resources/*.bpmn'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ZEEBE_ADDRESS: ${{ secrets.ZEEBE_ADDRESS }}
+          ZEEBE_CLIENT_ID: ${{ secrets.ZEEBE_CLIENT_ID }}
+          ZEEBE_CLIENT_SECRET: ${{ secrets.ZEEBE_CLIENT_SECRET }}
+          ZEEBE_AUTHORIZATION_SERVER_URL: ${{ secrets.ZEEBE_AUTHORIZATION_SERVER_URL }}
+      - uses: zeebe-io/zbctl-action@v0.0.7
+        name: Deploy BPMN
+        with:
+          version: '8.0.4'
+          command: 'deploy resource src/main/resources/*.dmn'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ZEEBE_ADDRESS: ${{ secrets.ZEEBE_ADDRESS }}


### PR DESCRIPTION
The previous solution didn't work. Let's just use 2 steps instead.

https://github.com/zeebe-io/zeebe-releaser/actions/runs/2710800683