### PR TITLE
Allow to built release-candidate

### DIFF
--- a/src/main/resources/build-release-candidate.bpmn
+++ b/src/main/resources/build-release-candidate.bpmn
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_01wel5n" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.3.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="Process_1w8vftu" name="build-release-candidate" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:userTaskForm id="UserTaskForm_38jg436">{
+  "schemaVersion": 2,
+  "components": [
+    {
+      "label": "Current release process",
+      "type": "textfield",
+      "id": "Field_0zdbd7q",
+      "key": "release_version"
+    },
+    {
+      "text": "# Run the release pipeline\n\nThe Zeebe release pipeline runs on the same Jenkins instance as the CI pipeline, [here](https://ci.zeebe.camunda.cloud/job/zeebe-release/).  The pipeline itself lives in the Zeebe repository, [here](https://github.com/camunda-cloud/zeebe/blob/develop/.ci/pipelines/release_zeebe.groovy). In short, it will build the release branch, stage and deploy Maven and Docker artifacts, tag the release, and update the version for the next development iteration. \n\n[Create a new build](https://ci.zeebe.camunda.cloud/job/zeebe-release/build?delay=0sec), and fill in the parameters accordingly.\n\n  \n**Alpha release**\n```\nRELEASE_VERSION: MAJOR.MINOR.0-ALPHA\nDEVELOPMENT_VERSION: MAJOR.MINOR.0-SNAPSHOT\nPUSH_CHANGES: true\nPUSH_DOCKER: true\nIS_LATEST: false\n```\n\n  \n**Patch release**\n\n&gt; **NOTE**: here the development version is MAJOR.MINOR.PATCH+1-SNAPSHOT. So if you have your release version is `1.2.1`, then the next development version will be `1.2.2-SNAPSHOT`.\n\n&gt; **NOTE**: if you are release a patch release for the latest minor release, then `IS_LATEST` should be set to `true`.\n\n```\nRELEASE_VERSION: MAJOR.MINOR.PATCH\nDEVELOPMENT_VERSION: MAJOR.MINOR.PATCH+1-SNAPSHOT\nPUSH_CHANGES: true\nPUSH_DOCKER: true\nIS_LATEST: false\n```\n\n  \n**Minor release**\n\n&gt; **NOTE**: here the development version is MAJOR.MINOR+1.0-SNAPSHOT. So if you have your release version is `1.2.0`, then the next development version will be `1.3.0-SNAPSHOT`.\n\n```\nRELEASE_VERSION: MAJOR.MINOR.0\nDEVELOPMENT_VERSION: MAJOR.MINOR+1.0-SNAPSHOT\nPUSH_CHANGES: true\nPUSH_DOCKER: true\nIS_LATEST: true\n```\n  \n  \nClick `Build` to start the release process, and wait until the pipeline finishes successfully.\n\nHints:\n- Sometimes the release process will fail. It's currently necessary to manually rollback the changes before restarting again. To roll back the changes, you will need to delete any tags that the job may have created (you can do so via the Github Web UI), and also drop the additional commits that the job added on the release branch, such that it's in the state it was before running the job. You may also have to drop the Maven artifacts on Maven central, [here](https://s01.oss.sonatype.org/).\n- If unsure about anything, ask the team and/or your tech lead.",
+      "type": "text",
+      "id": "Field_05xq34i"
+    }
+  ],
+  "type": "default",
+  "id": "Form_1ituz9d"
+}</zeebe:userTaskForm>
+      <zeebe:userTaskForm id="UserTaskForm_2j128s3">{
+  "schemaVersion": 2,
+  "components": [
+    {
+      "label": "Current release process",
+      "type": "textfield",
+      "id": "Field_01aedoc",
+      "key": "release_version"
+    },
+    {
+      "text": "# Release the Maven artifacts\n\nOnce the pipeline was successfully finished, the Docker artifacts will already be available publicly. We now have to release the Maven central ones.\n\n1. Go to [Maven Central](https://s01.oss.sonatype.org/) and login using the shared `Maven Central` credentials for login `camundabpm` found in [Keeper](https://keepersecurity.eu/vault/) under `Shared-Engineering - Zeebe`. \n2. On the left side, click on the 'Staging Repositories' link.\n3. After it has been loaded, scroll down to the bottom of the list. You should find the relevant Zeebe staging repositories there.\n4. Mark the repository you want to release, which should be one for zeebe.\n\n&gt; io.camunda:zeebe*\n\n\n5. Click on 'Release' at the menu on top of the list. A window will pop up were you can enter a description but it is not necessary. Activate 'Drop repository after release automatically'. Then proceed.\n6. Done.",
+      "type": "text",
+      "id": "Field_10avz1w"
+    }
+  ],
+  "type": "default",
+  "id": "Form_1tx0oak"
+}</zeebe:userTaskForm>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="StartEvent_1" name="Build release candidate">
+      <bpmn:outgoing>Flow_1yahb20</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:userTask id="Activity_0wjyoge" name="Trigger release candidate">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formKey="camunda-forms:bpmn:UserTaskForm_38jg436" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1yahb20</bpmn:incoming>
+      <bpmn:outgoing>Flow_0laljwe</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Activity_0x73wcr" name="Release on Maven Central">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formKey="camunda-forms:bpmn:UserTaskForm_2j128s3" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0laljwe</bpmn:incoming>
+      <bpmn:outgoing>Flow_0sjbp2b</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:serviceTask id="notify-others" name="Notify other teams" zeebe:modelerTemplate="io.camunda.connectors.Slack.v1" zeebe:modelerTemplateIcon="data:image/svg+xml;utf8,%3Csvg%20width%3D%2218%22%20height%3D%2218%22%20%20viewBox%3D%220%200%20127%20127%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%3Cpath%20d%3D%22M27.2%2080c0%207.3-5.9%2013.2-13.2%2013.2C6.7%2093.2.8%2087.3.8%2080c0-7.3%205.9-13.2%2013.2-13.2h13.2V80zm6.6%200c0-7.3%205.9-13.2%2013.2-13.2%207.3%200%2013.2%205.9%2013.2%2013.2v33c0%207.3-5.9%2013.2-13.2%2013.2-7.3%200-13.2-5.9-13.2-13.2V80z%22%20fill%3D%22%23E01E5A%22%2F%3E%0A%20%20%3Cpath%20d%3D%22M47%2027c-7.3%200-13.2-5.9-13.2-13.2C33.8%206.5%2039.7.6%2047%20.6c7.3%200%2013.2%205.9%2013.2%2013.2V27H47zm0%206.7c7.3%200%2013.2%205.9%2013.2%2013.2%200%207.3-5.9%2013.2-13.2%2013.2H13.9C6.6%2060.1.7%2054.2.7%2046.9c0-7.3%205.9-13.2%2013.2-13.2H47z%22%20fill%3D%22%2336C5F0%22%2F%3E%0A%20%20%3Cpath%20d%3D%22M99.9%2046.9c0-7.3%205.9-13.2%2013.2-13.2%207.3%200%2013.2%205.9%2013.2%2013.2%200%207.3-5.9%2013.2-13.2%2013.2H99.9V46.9zm-6.6%200c0%207.3-5.9%2013.2-13.2%2013.2-7.3%200-13.2-5.9-13.2-13.2V13.8C66.9%206.5%2072.8.6%2080.1.6c7.3%200%2013.2%205.9%2013.2%2013.2v33.1z%22%20fill%3D%22%232EB67D%22%2F%3E%0A%20%20%3Cpath%20d%3D%22M80.1%2099.8c7.3%200%2013.2%205.9%2013.2%2013.2%200%207.3-5.9%2013.2-13.2%2013.2-7.3%200-13.2-5.9-13.2-13.2V99.8h13.2zm0-6.6c-7.3%200-13.2-5.9-13.2-13.2%200-7.3%205.9-13.2%2013.2-13.2h33.1c7.3%200%2013.2%205.9%2013.2%2013.2%200%207.3-5.9%2013.2-13.2%2013.2H80.1z%22%20fill%3D%22%23ECB22E%22%2F%3E%0A%3C%2Fsvg%3E%0A">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda:slack:1" />
+        <zeebe:ioMapping>
+          <zeebe:input source="chat.postMessage" target="method" />
+          <zeebe:input source="secrets.SLACK_OAUTH_TOKEN" target="token" />
+          <zeebe:input source="#c8-release-announcements" target="data.channel" />
+          <zeebe:input source="= &#34;Hi :wave: team! There is a new Zeebe version &#34; + release_version + &#34; available that you can test against.&#34;" target="data.text" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="resultVariable" />
+          <zeebe:header key="resultExpression" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0sjbp2b</bpmn:incoming>
+      <bpmn:outgoing>Flow_1g3i425</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:callActivity id="Activity_1aiu7sp" name="Release Zeebe process test">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="zeebe-process-test-release" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1g3i425</bpmn:incoming>
+      <bpmn:outgoing>Flow_0084v7j</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_0laljwe" sourceRef="Activity_0wjyoge" targetRef="Activity_0x73wcr" />
+    <bpmn:sequenceFlow id="Flow_0sjbp2b" sourceRef="Activity_0x73wcr" targetRef="notify-others" />
+    <bpmn:sequenceFlow id="Flow_1g3i425" sourceRef="notify-others" targetRef="Activity_1aiu7sp" />
+    <bpmn:sequenceFlow id="Flow_1yahb20" sourceRef="StartEvent_1" targetRef="Activity_0wjyoge" />
+    <bpmn:endEvent id="Event_00xlnce" name="Release candidate built">
+      <bpmn:incoming>Flow_0084v7j</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0084v7j" sourceRef="Activity_1aiu7sp" targetRef="Event_00xlnce" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1w8vftu">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="166" y="142" width="64" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0k10z92" bpmnElement="Activity_0wjyoge">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1xi5jc4" bpmnElement="Activity_0x73wcr">
+        <dc:Bounds x="420" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0v48l92_di" bpmnElement="notify-others">
+        <dc:Bounds x="550" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sfwg0q" bpmnElement="Activity_1aiu7sp">
+        <dc:Bounds x="700" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_00xlnce_di" bpmnElement="Event_00xlnce">
+        <dc:Bounds x="852" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="835" y="142" width="71" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0laljwe_di" bpmnElement="Flow_0laljwe">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="420" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0sjbp2b_di" bpmnElement="Flow_0sjbp2b">
+        <di:waypoint x="520" y="117" />
+        <di:waypoint x="550" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1g3i425_di" bpmnElement="Flow_1g3i425">
+        <di:waypoint x="650" y="117" />
+        <di:waypoint x="700" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1yahb20_di" bpmnElement="Flow_1yahb20">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0084v7j_di" bpmnElement="Flow_0084v7j">
+        <di:waypoint x="800" y="117" />
+        <di:waypoint x="852" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/main/resources/qa.bpmn
+++ b/src/main/resources/qa.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1pwapqm" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.12.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.1.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1pwapqm" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.3.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.1.0">
   <bpmn:process id="zeebe-release-qa" name="Zeebe Release QA" isExecutable="true">
     <bpmn:extensionElements>
       <zeebe:userTaskForm id="userTaskForm_1b9cav3">{
@@ -272,7 +272,6 @@
   "executionPlatformVersion": "1.2"
 }</zeebe:userTaskForm>
       <zeebe:userTaskForm id="userTaskForm_0h186at">{
-  "schemaVersion": 2,
   "components": [
     {
       "label": "Current release version",
@@ -281,13 +280,19 @@
       "key": "release_version"
     },
     {
-      "text": "# Run E2E test\n\nBuild an image for the release version if it doesn't already exists. Image should be already available if you have setup the benchmark. \n\nRun github action https://github.com/zeebe-io/zeebe-e2e-test/actions/workflows/runtest.yml to start a e2e test on the release branch\n with following parameters:\n\n- Zeebe docker image with version: gcr.io/zeebe-io/zeebe:release-MAJOR-MINOR-PATCH-ALPHA\n- Generation template: Zeebe SNAPSHOT\n- Test duration*: R1/P7D \n- A string to identify the run: E2E Tests : rc-MAJOR-MINOR-PATH-ALPHA\n\nThis will start an e2e test and run it for the given duration. If the test fails, you will get a notification in #zeebe-ci channel. \n\nEnsure the test is started by checking Operate of Testbench-prod cluster https://console.cloud.ultrawombat.com/org/f1155314-5031-4a84-9e29-58f69f8ab242/cluster/7b2cd3f5-cfcc-4a65-ab22-0ccaa071e68e ",
+      "text": "# Run E2E test\n\nUse release candidate to test against.\n\nRun github action https://github.com/zeebe-io/zeebe-e2e-test/actions/workflows/runtest.yml to start a e2e test on the release branch\n with following parameters:\n\n- Zeebe docker image with version: camunda:zeebe:MAJOR-MINOR-PATCH-rc\n- Generation template: Zeebe SNAPSHOT\n- Test duration*: R1/P7D \n- A string to identify the run: E2E Tests : rc-MAJOR-MINOR-PATH-ALPHA\n\nThis will start an e2e test and run it for the given duration. If the test fails, you will get a notification in #zeebe-ci channel. \n\nEnsure the test is started by checking Operate of Testbench-prod cluster https://console.cloud.ultrawombat.com/org/f1155314-5031-4a84-9e29-58f69f8ab242/cluster/7b2cd3f5-cfcc-4a65-ab22-0ccaa071e68e ",
       "type": "text",
       "id": "Field_0r53wcj"
     }
   ],
+  "schemaVersion": 4,
   "type": "default",
-  "id": "qa_e2e_form"</zeebe:userTaskForm>
+  "id": "qa_e2e_form",
+  "exporter": {
+    "name": "Camunda Modeler",
+    "version": "5.3.0"
+  }
+}</zeebe:userTaskForm>
     </bpmn:extensionElements>
     <bpmn:sequenceFlow id="Flow_1u6won8" sourceRef="build-ci-with-qa" targetRef="check-qa-results" />
     <bpmn:startEvent id="Event_0vq2qf4" name="Code Freezed">
@@ -515,85 +520,6 @@ correlation-key: release_version</bpmn:text>
   </bpmn:message>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="zeebe-release-qa">
-      <bpmndi:BPMNEdge id="Flow_0outxba_di" bpmnElement="Flow_0outxba">
-        <di:waypoint x="1300" y="240" />
-        <di:waypoint x="1365" y="240" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1ewrj5i_di" bpmnElement="Flow_1ewrj5i">
-        <di:waypoint x="1795" y="240" />
-        <di:waypoint x="1852" y="240" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1s5mjw5_di" bpmnElement="Flow_1s5mjw5">
-        <di:waypoint x="940" y="215" />
-        <di:waypoint x="940" y="120" />
-        <di:waypoint x="1770" y="120" />
-        <di:waypoint x="1770" y="215" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="951" y="188" width="19" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0sinhos_di" bpmnElement="Flow_0sinhos">
-        <di:waypoint x="965" y="240" />
-        <di:waypoint x="1040" y="240" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1g3lnif_di" bpmnElement="Flow_1g3lnif">
-        <di:waypoint x="1390" y="265" />
-        <di:waypoint x="1390" y="350" />
-        <di:waypoint x="578" y="350" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0cnrtm2_di" bpmnElement="Flow_0cnrtm2">
-        <di:waypoint x="542" y="350" />
-        <di:waypoint x="420" y="350" />
-        <di:waypoint x="420" y="280" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1x9lmny_di" bpmnElement="Flow_1x9lmny">
-        <di:waypoint x="830" y="215" />
-        <di:waypoint x="830" y="120" />
-        <di:waypoint x="660" y="120" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="745" y="129" width="15" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_02b0qqa_di" bpmnElement="Flow_02b0qqa">
-        <di:waypoint x="855" y="240" />
-        <di:waypoint x="915" y="240" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="993" y="222" width="15" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_172mjv0_di" bpmnElement="Flow_172mjv0">
-        <di:waypoint x="660" y="240" />
-        <di:waypoint x="805" y="240" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1puyfkr_di" bpmnElement="Flow_1puyfkr">
-        <di:waypoint x="560" y="120" />
-        <di:waypoint x="420" y="120" />
-        <di:waypoint x="420" y="200" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_091kws4_di" bpmnElement="Flow_091kws4">
-        <di:waypoint x="1680" y="240" />
-        <di:waypoint x="1745" y="240" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_10auxgf_di" bpmnElement="Flow_10auxgf">
-        <di:waypoint x="1518" y="240" />
-        <di:waypoint x="1580" y="240" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0epbj3m_di" bpmnElement="Flow_0epbj3m">
-        <di:waypoint x="1415" y="240" />
-        <di:waypoint x="1482" y="240" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ytbx0r_di" bpmnElement="Flow_0ytbx0r">
-        <di:waypoint x="1140" y="240" />
-        <di:waypoint x="1200" y="240" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_10fj3ib_di" bpmnElement="Flow_10fj3ib">
-        <di:waypoint x="268" y="240" />
-        <di:waypoint x="370" y="240" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1u6won8_di" bpmnElement="Flow_1u6won8">
-        <di:waypoint x="470" y="240" />
-        <di:waypoint x="560" y="240" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_0vq2qf4_di" bpmnElement="Event_0vq2qf4">
         <dc:Bounds x="232" y="222" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -603,96 +529,6 @@ correlation-key: release_version</bpmn:text>
       <bpmndi:BPMNShape id="Activity_1hvqv2b_di" bpmnElement="daily-task-event-subprocess" isExpanded="true">
         <dc:Bounds x="215" y="420" width="1225" height="600" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_18xopoc_di" bpmnElement="Flow_18xopoc">
-        <di:waypoint x="1100" y="775" />
-        <di:waypoint x="1100" y="605" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_131el46_di" bpmnElement="Flow_131el46">
-        <di:waypoint x="1005" y="580" />
-        <di:waypoint x="1075" y="580" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0o0yeym_di" bpmnElement="Flow_0o0yeym">
-        <di:waypoint x="1235" y="580" />
-        <di:waypoint x="1302" y="580" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_13ht5oh_di" bpmnElement="Flow_13ht5oh">
-        <di:waypoint x="440" y="555" />
-        <di:waypoint x="440" y="480" />
-        <di:waypoint x="1210" y="480" />
-        <di:waypoint x="1210" y="555" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="451" y="525" width="19" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0n59tzo_di" bpmnElement="Flow_0n59tzo">
-        <di:waypoint x="465" y="580" />
-        <di:waypoint x="560" y="580" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="482" y="562" width="15" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0pmk4ca_di" bpmnElement="Flow_0pmk4ca">
-        <di:waypoint x="635" y="920" />
-        <di:waypoint x="1100" y="920" />
-        <di:waypoint x="1100" y="830" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_03ccwuo_di" bpmnElement="Flow_03ccwuo">
-        <di:waypoint x="610" y="800" />
-        <di:waypoint x="1075" y="800" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="629" y="782" width="15" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0m22asp_di" bpmnElement="Flow_0m22asp">
-        <di:waypoint x="1125" y="580" />
-        <di:waypoint x="1185" y="580" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_014nhup_di" bpmnElement="Flow_014nhup">
-        <di:waypoint x="585" y="825" />
-        <di:waypoint x="585" y="880" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="596" y="833" width="19" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1ceu93t_di" bpmnElement="Flow_1ceu93t">
-        <di:waypoint x="585" y="730" />
-        <di:waypoint x="585" y="775" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1mc3iqv_di" bpmnElement="Flow_1mc3iqv">
-        <di:waypoint x="585" y="605" />
-        <di:waypoint x="585" y="650" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0xui8t5_di" bpmnElement="Flow_0xui8t5">
-        <di:waypoint x="610" y="580" />
-        <di:waypoint x="675" y="580" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0edaypg_di" bpmnElement="Flow_0edaypg">
-        <di:waypoint x="875" y="690" />
-        <di:waypoint x="980" y="690" />
-        <di:waypoint x="980" y="605" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1c95oe2_di" bpmnElement="Flow_1c95oe2">
-        <di:waypoint x="825" y="605" />
-        <di:waypoint x="825" y="650" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="832" y="625" width="19" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_14416rg_di" bpmnElement="Flow_14416rg">
-        <di:waypoint x="850" y="580" />
-        <di:waypoint x="955" y="580" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="854" y="562" width="15" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_13l5xfp_di" bpmnElement="Flow_13l5xfp">
-        <di:waypoint x="775" y="580" />
-        <di:waypoint x="800" y="580" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ogr394_di" bpmnElement="Flow_0ogr394">
-        <di:waypoint x="343" y="580" />
-        <di:waypoint x="415" y="580" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1bo2qwj_di" bpmnElement="Event_1bo2qwj">
         <dc:Bounds x="1302" y="562" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -750,6 +586,96 @@ correlation-key: release_version</bpmn:text>
       <bpmndi:BPMNShape id="Gateway_0wm06h0_di" bpmnElement="Gateway_0wm06h0" isMarkerVisible="true">
         <dc:Bounds x="955" y="555" width="50" height="50" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0ogr394_di" bpmnElement="Flow_0ogr394">
+        <di:waypoint x="343" y="580" />
+        <di:waypoint x="415" y="580" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13l5xfp_di" bpmnElement="Flow_13l5xfp">
+        <di:waypoint x="775" y="580" />
+        <di:waypoint x="800" y="580" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14416rg_di" bpmnElement="Flow_14416rg">
+        <di:waypoint x="850" y="580" />
+        <di:waypoint x="955" y="580" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="854" y="562" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c95oe2_di" bpmnElement="Flow_1c95oe2">
+        <di:waypoint x="825" y="605" />
+        <di:waypoint x="825" y="650" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="832" y="625" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0edaypg_di" bpmnElement="Flow_0edaypg">
+        <di:waypoint x="875" y="690" />
+        <di:waypoint x="980" y="690" />
+        <di:waypoint x="980" y="605" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0xui8t5_di" bpmnElement="Flow_0xui8t5">
+        <di:waypoint x="610" y="580" />
+        <di:waypoint x="675" y="580" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1mc3iqv_di" bpmnElement="Flow_1mc3iqv">
+        <di:waypoint x="585" y="605" />
+        <di:waypoint x="585" y="650" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ceu93t_di" bpmnElement="Flow_1ceu93t">
+        <di:waypoint x="585" y="730" />
+        <di:waypoint x="585" y="775" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_014nhup_di" bpmnElement="Flow_014nhup">
+        <di:waypoint x="585" y="825" />
+        <di:waypoint x="585" y="880" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="596" y="833" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0m22asp_di" bpmnElement="Flow_0m22asp">
+        <di:waypoint x="1125" y="580" />
+        <di:waypoint x="1185" y="580" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_03ccwuo_di" bpmnElement="Flow_03ccwuo">
+        <di:waypoint x="610" y="800" />
+        <di:waypoint x="1075" y="800" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="629" y="782" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0pmk4ca_di" bpmnElement="Flow_0pmk4ca">
+        <di:waypoint x="635" y="920" />
+        <di:waypoint x="1100" y="920" />
+        <di:waypoint x="1100" y="830" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0n59tzo_di" bpmnElement="Flow_0n59tzo">
+        <di:waypoint x="465" y="580" />
+        <di:waypoint x="560" y="580" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="482" y="562" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13ht5oh_di" bpmnElement="Flow_13ht5oh">
+        <di:waypoint x="440" y="555" />
+        <di:waypoint x="440" y="480" />
+        <di:waypoint x="1210" y="480" />
+        <di:waypoint x="1210" y="555" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="451" y="525" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0o0yeym_di" bpmnElement="Flow_0o0yeym">
+        <di:waypoint x="1235" y="580" />
+        <di:waypoint x="1302" y="580" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_131el46_di" bpmnElement="Flow_131el46">
+        <di:waypoint x="1005" y="580" />
+        <di:waypoint x="1075" y="580" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_18xopoc_di" bpmnElement="Flow_18xopoc">
+        <di:waypoint x="1100" y="775" />
+        <di:waypoint x="1100" y="605" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Gateway_09o8vm7_di" bpmnElement="Gateway_1sp4w8i">
         <dc:Bounds x="1365" y="215" width="50" height="50" />
       </bpmndi:BPMNShape>
@@ -810,6 +736,85 @@ correlation-key: release_version</bpmn:text>
       <bpmndi:BPMNShape id="TextAnnotation_1t8yrh0_di" bpmnElement="TextAnnotation_1t8yrh0">
         <dc:Bounds x="470" y="290" width="207" height="42" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1u6won8_di" bpmnElement="Flow_1u6won8">
+        <di:waypoint x="470" y="240" />
+        <di:waypoint x="560" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10fj3ib_di" bpmnElement="Flow_10fj3ib">
+        <di:waypoint x="268" y="240" />
+        <di:waypoint x="370" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ytbx0r_di" bpmnElement="Flow_0ytbx0r">
+        <di:waypoint x="1140" y="240" />
+        <di:waypoint x="1200" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0epbj3m_di" bpmnElement="Flow_0epbj3m">
+        <di:waypoint x="1415" y="240" />
+        <di:waypoint x="1482" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10auxgf_di" bpmnElement="Flow_10auxgf">
+        <di:waypoint x="1518" y="240" />
+        <di:waypoint x="1580" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_091kws4_di" bpmnElement="Flow_091kws4">
+        <di:waypoint x="1680" y="240" />
+        <di:waypoint x="1745" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1puyfkr_di" bpmnElement="Flow_1puyfkr">
+        <di:waypoint x="560" y="120" />
+        <di:waypoint x="420" y="120" />
+        <di:waypoint x="420" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_172mjv0_di" bpmnElement="Flow_172mjv0">
+        <di:waypoint x="660" y="240" />
+        <di:waypoint x="805" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_02b0qqa_di" bpmnElement="Flow_02b0qqa">
+        <di:waypoint x="855" y="240" />
+        <di:waypoint x="915" y="240" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="993" y="222" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1x9lmny_di" bpmnElement="Flow_1x9lmny">
+        <di:waypoint x="830" y="215" />
+        <di:waypoint x="830" y="120" />
+        <di:waypoint x="660" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="745" y="129" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0cnrtm2_di" bpmnElement="Flow_0cnrtm2">
+        <di:waypoint x="542" y="350" />
+        <di:waypoint x="420" y="350" />
+        <di:waypoint x="420" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1g3lnif_di" bpmnElement="Flow_1g3lnif">
+        <di:waypoint x="1390" y="265" />
+        <di:waypoint x="1390" y="350" />
+        <di:waypoint x="578" y="350" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0sinhos_di" bpmnElement="Flow_0sinhos">
+        <di:waypoint x="965" y="240" />
+        <di:waypoint x="1040" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1s5mjw5_di" bpmnElement="Flow_1s5mjw5">
+        <di:waypoint x="940" y="215" />
+        <di:waypoint x="940" y="120" />
+        <di:waypoint x="1770" y="120" />
+        <di:waypoint x="1770" y="215" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="951" y="188" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ewrj5i_di" bpmnElement="Flow_1ewrj5i">
+        <di:waypoint x="1795" y="240" />
+        <di:waypoint x="1852" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0outxba_di" bpmnElement="Flow_0outxba">
+        <di:waypoint x="1300" y="240" />
+        <di:waypoint x="1365" y="240" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Association_0w2kh4q_di" bpmnElement="Association_0w2kh4q">
         <di:waypoint x="243" y="224" />
         <di:waypoint x="221" y="170" />

--- a/src/main/resources/qa_e2e.form
+++ b/src/main/resources/qa_e2e.form
@@ -1,5 +1,4 @@
 {
-  "schemaVersion": 2,
   "components": [
     {
       "label": "Current release version",
@@ -8,11 +7,16 @@
       "key": "release_version"
     },
     {
-      "text": "# Run E2E test\n\nBuild an image for the release version if it doesn't already exists. Image should be already available if you have setup the benchmark. \n\nRun github action https://github.com/zeebe-io/zeebe-e2e-test/actions/workflows/runtest.yml to start a e2e test on the release branch\n with following parameters:\n\n- Zeebe docker image with version: gcr.io/zeebe-io/zeebe:release-MAJOR-MINOR-PATCH-ALPHA\n- Generation template: Zeebe SNAPSHOT\n- Test duration*: R1/P7D \n- A string to identify the run: E2E Tests : rc-MAJOR-MINOR-PATH-ALPHA\n\nThis will start an e2e test and run it for the given duration. If the test fails, you will get a notification in #zeebe-ci channel. \n\nEnsure the test is started by checking Operate of Testbench-prod cluster https://console.cloud.ultrawombat.com/org/f1155314-5031-4a84-9e29-58f69f8ab242/cluster/7b2cd3f5-cfcc-4a65-ab22-0ccaa071e68e ",
+      "text": "# Run E2E test\n\nUse release candidate to test against.\n\nRun github action https://github.com/zeebe-io/zeebe-e2e-test/actions/workflows/runtest.yml to start a e2e test on the release branch\n with following parameters:\n\n- Zeebe docker image with version: camunda:zeebe:MAJOR-MINOR-PATCH-rc\n- Generation template: Zeebe SNAPSHOT\n- Test duration*: R1/P7D \n- A string to identify the run: E2E Tests : rc-MAJOR-MINOR-PATH-ALPHA\n\nThis will start an e2e test and run it for the given duration. If the test fails, you will get a notification in #zeebe-ci channel. \n\nEnsure the test is started by checking Operate of Testbench-prod cluster https://console.cloud.ultrawombat.com/org/f1155314-5031-4a84-9e29-58f69f8ab242/cluster/7b2cd3f5-cfcc-4a65-ab22-0ccaa071e68e ",
       "type": "text",
       "id": "Field_0r53wcj"
     }
   ],
+  "schemaVersion": 4,
   "type": "default",
-  "id": "qa_e2e_form"
+  "id": "qa_e2e_form",
+  "exporter": {
+    "name": "Camunda Modeler",
+    "version": "5.3.0"
+  }
 }

--- a/src/main/resources/zeebe_release.bpmn
+++ b/src/main/resources/zeebe_release.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1sojgd1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.12.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1sojgd1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.3.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
   <bpmn:process id="zeebe-release-process" name="Zeebe release" isExecutable="true">
     <bpmn:extensionElements>
       <zeebe:userTaskForm id="userTaskForm_0uh0d7s">{
@@ -108,6 +108,42 @@
   "id": "release_backport_label",
   "executionPlatform": "Camunda Cloud",
   "executionPlatformVersion": "1.2"
+}</zeebe:userTaskForm>
+      <zeebe:userTaskForm id="UserTaskForm_0106sqk">{
+  "schemaVersion": 2,
+  "components": [
+    {
+      "label": "Current release process",
+      "type": "textfield",
+      "id": "Field_0zdbd7q",
+      "key": "release_version"
+    },
+    {
+      "text": "# Run the release pipeline\n\nThe Zeebe release pipeline runs on the same Jenkins instance as the CI pipeline, [here](https://ci.zeebe.camunda.cloud/job/zeebe-release/).  The pipeline itself lives in the Zeebe repository, [here](https://github.com/camunda-cloud/zeebe/blob/develop/.ci/pipelines/release_zeebe.groovy). In short, it will build the release branch, stage and deploy Maven and Docker artifacts, tag the release, and update the version for the next development iteration. \n\n[Create a new build](https://ci.zeebe.camunda.cloud/job/zeebe-release/build?delay=0sec), and fill in the parameters accordingly.\n\n  \n**Alpha release**\n```\nRELEASE_VERSION: MAJOR.MINOR.0-ALPHA\nDEVELOPMENT_VERSION: MAJOR.MINOR.0-SNAPSHOT\nPUSH_CHANGES: true\nPUSH_DOCKER: true\nIS_LATEST: false\n```\n\n  \n**Patch release**\n\n&gt; **NOTE**: here the development version is MAJOR.MINOR.PATCH+1-SNAPSHOT. So if you have your release version is `1.2.1`, then the next development version will be `1.2.2-SNAPSHOT`.\n\n&gt; **NOTE**: if you are release a patch release for the latest minor release, then `IS_LATEST` should be set to `true`.\n\n```\nRELEASE_VERSION: MAJOR.MINOR.PATCH\nDEVELOPMENT_VERSION: MAJOR.MINOR.PATCH+1-SNAPSHOT\nPUSH_CHANGES: true\nPUSH_DOCKER: true\nIS_LATEST: false\n```\n\n  \n**Minor release**\n\n&gt; **NOTE**: here the development version is MAJOR.MINOR+1.0-SNAPSHOT. So if you have your release version is `1.2.0`, then the next development version will be `1.3.0-SNAPSHOT`.\n\n```\nRELEASE_VERSION: MAJOR.MINOR.0\nDEVELOPMENT_VERSION: MAJOR.MINOR+1.0-SNAPSHOT\nPUSH_CHANGES: true\nPUSH_DOCKER: true\nIS_LATEST: true\n```\n  \n  \nClick `Build` to start the release process, and wait until the pipeline finishes successfully.\n\nHints:\n- Sometimes the release process will fail. It's currently necessary to manually rollback the changes before restarting again. To roll back the changes, you will need to delete any tags that the job may have created (you can do so via the Github Web UI), and also drop the additional commits that the job added on the release branch, such that it's in the state it was before running the job. You may also have to drop the Maven artifacts on Maven central, [here](https://s01.oss.sonatype.org/).\n- If unsure about anything, ask the team and/or your tech lead.",
+      "type": "text",
+      "id": "Field_05xq34i"
+    }
+  ],
+  "type": "default",
+  "id": "Form_1ituz9d"
+}</zeebe:userTaskForm>
+      <zeebe:userTaskForm id="UserTaskForm_1fmei0t">{
+  "schemaVersion": 2,
+  "components": [
+    {
+      "label": "Current release process",
+      "type": "textfield",
+      "id": "Field_01aedoc",
+      "key": "release_version"
+    },
+    {
+      "text": "# Release the Maven artifacts\n\nOnce the pipeline was successfully finished, the Docker artifacts will already be available publicly. We now have to release the Maven central ones.\n\n1. Go to [Maven Central](https://s01.oss.sonatype.org/) and login using the shared `Maven Central` credentials for login `camundabpm` found in [Keeper](https://keepersecurity.eu/vault/) under `Shared-Engineering - Zeebe`. \n2. On the left side, click on the 'Staging Repositories' link.\n3. After it has been loaded, scroll down to the bottom of the list. You should find the relevant Zeebe staging repositories there.\n4. Mark the repository you want to release, which should be one for zeebe.\n\n&gt; io.camunda:zeebe*\n\n\n5. Click on 'Release' at the menu on top of the list. A window will pop up were you can enter a description but it is not necessary. Activate 'Drop repository after release automatically'. Then proceed.\n6. Done.",
+      "type": "text",
+      "id": "Field_10avz1w"
+    }
+  ],
+  "type": "default",
+  "id": "Form_1tx0oak"
 }</zeebe:userTaskForm>
     </bpmn:extensionElements>
     <bpmn:startEvent id="StartEvent_1" name="Release started">
@@ -281,97 +317,75 @@
       </bpmn:sequenceFlow>
       <bpmn:sequenceFlow id="Flow_06yz81p" name="No" sourceRef="Gateway_0pprots" targetRef="Event_09hnipm" />
     </bpmn:subProcess>
+    <bpmn:subProcess id="Activity_0caepsu" name="Release Candidate" triggeredByEvent="true">
+      <bpmn:startEvent id="Event_072g6mg" name="Built release candidate">
+        <bpmn:outgoing>Flow_1c2xzxq</bpmn:outgoing>
+        <bpmn:messageEventDefinition id="MessageEventDefinition_0qd3cau" messageRef="Message_36527rk" />
+      </bpmn:startEvent>
+      <bpmn:userTask id="Activity_0wjyoge" name="Trigger release candidate">
+        <bpmn:extensionElements>
+          <zeebe:formDefinition formKey="camunda-forms:bpmn:UserTaskForm_0106sqk" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_1c2xzxq</bpmn:incoming>
+        <bpmn:outgoing>Flow_0laljwe</bpmn:outgoing>
+      </bpmn:userTask>
+      <bpmn:sequenceFlow id="Flow_1c2xzxq" sourceRef="Event_072g6mg" targetRef="Activity_0wjyoge" />
+      <bpmn:userTask id="Activity_0x73wcr" name="Release on Maven Central">
+        <bpmn:extensionElements>
+          <zeebe:formDefinition formKey="camunda-forms:bpmn:UserTaskForm_1fmei0t" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_0laljwe</bpmn:incoming>
+        <bpmn:outgoing>Flow_0sjbp2b</bpmn:outgoing>
+      </bpmn:userTask>
+      <bpmn:sequenceFlow id="Flow_0laljwe" sourceRef="Activity_0wjyoge" targetRef="Activity_0x73wcr" />
+      <bpmn:serviceTask id="notify-others" name="Notify other teams" zeebe:modelerTemplate="io.camunda.connectors.Slack.v1" zeebe:modelerTemplateIcon="data:image/svg+xml;utf8,%3Csvg%20width%3D%2218%22%20height%3D%2218%22%20%20viewBox%3D%220%200%20127%20127%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%3Cpath%20d%3D%22M27.2%2080c0%207.3-5.9%2013.2-13.2%2013.2C6.7%2093.2.8%2087.3.8%2080c0-7.3%205.9-13.2%2013.2-13.2h13.2V80zm6.6%200c0-7.3%205.9-13.2%2013.2-13.2%207.3%200%2013.2%205.9%2013.2%2013.2v33c0%207.3-5.9%2013.2-13.2%2013.2-7.3%200-13.2-5.9-13.2-13.2V80z%22%20fill%3D%22%23E01E5A%22%2F%3E%0A%20%20%3Cpath%20d%3D%22M47%2027c-7.3%200-13.2-5.9-13.2-13.2C33.8%206.5%2039.7.6%2047%20.6c7.3%200%2013.2%205.9%2013.2%2013.2V27H47zm0%206.7c7.3%200%2013.2%205.9%2013.2%2013.2%200%207.3-5.9%2013.2-13.2%2013.2H13.9C6.6%2060.1.7%2054.2.7%2046.9c0-7.3%205.9-13.2%2013.2-13.2H47z%22%20fill%3D%22%2336C5F0%22%2F%3E%0A%20%20%3Cpath%20d%3D%22M99.9%2046.9c0-7.3%205.9-13.2%2013.2-13.2%207.3%200%2013.2%205.9%2013.2%2013.2%200%207.3-5.9%2013.2-13.2%2013.2H99.9V46.9zm-6.6%200c0%207.3-5.9%2013.2-13.2%2013.2-7.3%200-13.2-5.9-13.2-13.2V13.8C66.9%206.5%2072.8.6%2080.1.6c7.3%200%2013.2%205.9%2013.2%2013.2v33.1z%22%20fill%3D%22%232EB67D%22%2F%3E%0A%20%20%3Cpath%20d%3D%22M80.1%2099.8c7.3%200%2013.2%205.9%2013.2%2013.2%200%207.3-5.9%2013.2-13.2%2013.2-7.3%200-13.2-5.9-13.2-13.2V99.8h13.2zm0-6.6c-7.3%200-13.2-5.9-13.2-13.2%200-7.3%205.9-13.2%2013.2-13.2h33.1c7.3%200%2013.2%205.9%2013.2%2013.2%200%207.3-5.9%2013.2-13.2%2013.2H80.1z%22%20fill%3D%22%23ECB22E%22%2F%3E%0A%3C%2Fsvg%3E%0A">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="io.camunda:slack:1" />
+          <zeebe:ioMapping>
+            <zeebe:input source="chat.postMessage" target="method" />
+            <zeebe:input source="secrets.SLACK_OAUTH_TOKEN" target="token" />
+            <zeebe:input source="#c8-release-announcements" target="data.channel" />
+            <zeebe:input source="= &#34;Hi :wave: team! There is a new Zeebe version &#34; + release_version + &#34; available that you can test against.&#34;" target="data.text" />
+          </zeebe:ioMapping>
+          <zeebe:taskHeaders>
+            <zeebe:header key="resultVariable" />
+            <zeebe:header key="resultExpression" />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_0sjbp2b</bpmn:incoming>
+        <bpmn:outgoing>Flow_1g3i425</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:sequenceFlow id="Flow_0sjbp2b" sourceRef="Activity_0x73wcr" targetRef="notify-others" />
+      <bpmn:callActivity id="Activity_1aiu7sp" name="Release Zeebe process test">
+        <bpmn:extensionElements>
+          <zeebe:calledElement processId="zeebe-process-test-release" propagateAllChildVariables="false" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_1g3i425</bpmn:incoming>
+        <bpmn:outgoing>Flow_0ynyan2</bpmn:outgoing>
+      </bpmn:callActivity>
+      <bpmn:sequenceFlow id="Flow_1g3i425" sourceRef="notify-others" targetRef="Activity_1aiu7sp" />
+      <bpmn:endEvent id="Event_0hfv9hy">
+        <bpmn:incoming>Flow_0ynyan2</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_0ynyan2" sourceRef="Activity_1aiu7sp" targetRef="Event_0hfv9hy" />
+      <bpmn:textAnnotation id="TextAnnotation_1oejvef">
+        <bpmn:text>correlationKey: release-branch-name
+messageName: rc</bpmn:text>
+      </bpmn:textAnnotation>
+      <bpmn:association id="Association_1b25zkd" sourceRef="Event_072g6mg" targetRef="TextAnnotation_1oejvef" />
+    </bpmn:subProcess>
     <bpmn:textAnnotation id="TextAnnotation_15g9k3f">
       <bpmn:text>req: release_version: string</bpmn:text>
     </bpmn:textAnnotation>
     <bpmn:association id="Association_0uafnuq" sourceRef="StartEvent_1" targetRef="TextAnnotation_15g9k3f" />
   </bpmn:process>
+  <bpmn:message id="Message_36527rk" name="rc">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=release_branch_name" />
+    </bpmn:extensionElements>
+  </bpmn:message>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="zeebe-release-process">
-      <bpmndi:BPMNEdge id="Flow_0v65v05_di" bpmnElement="Flow_0v65v05">
-        <di:waypoint x="1875" y="187" />
-        <di:waypoint x="1942" y="187" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1qzzlnv_di" bpmnElement="Flow_1qzzlnv">
-        <di:waypoint x="1760" y="320" />
-        <di:waypoint x="1850" y="320" />
-        <di:waypoint x="1850" y="212" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0vzb5ay_di" bpmnElement="Flow_0vzb5ay">
-        <di:waypoint x="1480" y="187" />
-        <di:waypoint x="1535" y="187" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0oxw9zk_di" bpmnElement="Flow_0oxw9zk">
-        <di:waypoint x="1180" y="187" />
-        <di:waypoint x="1240" y="187" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1ca8m5f_di" bpmnElement="Flow_1ca8m5f">
-        <di:waypoint x="665" y="187" />
-        <di:waypoint x="720" y="187" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_12ar9lm_di" bpmnElement="Flow_12ar9lm">
-        <di:waypoint x="450" y="187" />
-        <di:waypoint x="495" y="187" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0fmnken_di" bpmnElement="Flow_0fmnken">
-        <di:waypoint x="1025" y="187" />
-        <di:waypoint x="1080" y="187" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1n61zbo_di" bpmnElement="Flow_1n61zbo">
-        <di:waypoint x="520" y="162" />
-        <di:waypoint x="520" y="100" />
-        <di:waypoint x="1000" y="100" />
-        <di:waypoint x="1000" y="160" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="762" y="83" width="15" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_12eezq7_di" bpmnElement="Flow_12eezq7">
-        <di:waypoint x="545" y="187" />
-        <di:waypoint x="615" y="187" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="571" y="169" width="19" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1epwomt_di" bpmnElement="Flow_1epwomt">
-        <di:waypoint x="1585" y="187" />
-        <di:waypoint x="1660" y="187" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1getqr6_di" bpmnElement="Flow_1getqr6">
-        <di:waypoint x="820" y="187" />
-        <di:waypoint x="875" y="187" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0zhm3wb_di" bpmnElement="Flow_0zhm3wb">
-        <di:waypoint x="1760" y="187" />
-        <di:waypoint x="1825" y="187" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ttdn03_di" bpmnElement="Flow_0ttdn03">
-        <di:waypoint x="1560" y="212" />
-        <di:waypoint x="1560" y="320" />
-        <di:waypoint x="1660" y="320" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_05sub3t_di" bpmnElement="Flow_05sub3t">
-        <di:waypoint x="1340" y="187" />
-        <di:waypoint x="1380" y="187" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0s1b66d_di" bpmnElement="Flow_0s1b66d">
-        <di:waypoint x="925" y="187" />
-        <di:waypoint x="975" y="187" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1edl8wf_di" bpmnElement="Flow_1edl8wf">
-        <di:waypoint x="820" y="300" />
-        <di:waypoint x="900" y="300" />
-        <di:waypoint x="900" y="212" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1oxyoos_di" bpmnElement="Flow_1oxyoos">
-        <di:waypoint x="640" y="212" />
-        <di:waypoint x="640" y="300" />
-        <di:waypoint x="720" y="300" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1ew46h4_di" bpmnElement="Flow_1ew46h4">
-        <di:waypoint x="248" y="187" />
-        <di:waypoint x="350" y="187" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="212" y="169" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -433,30 +447,6 @@
         <dc:Bounds x="250" y="420" width="480" height="240" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_06yz81p_di" bpmnElement="Flow_06yz81p">
-        <di:waypoint x="400" y="545" />
-        <di:waypoint x="400" y="630" />
-        <di:waypoint x="660" y="630" />
-        <di:waypoint x="660" y="538" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="412" y="553" width="15" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1eq00q6_di" bpmnElement="Flow_1eq00q6">
-        <di:waypoint x="425" y="520" />
-        <di:waypoint x="480" y="520" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="444" y="502" width="18" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1oe0aef_di" bpmnElement="Flow_1oe0aef">
-        <di:waypoint x="580" y="520" />
-        <di:waypoint x="642" y="520" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1khohx9_di" bpmnElement="Flow_1khohx9">
-        <di:waypoint x="326" y="520" />
-        <di:waypoint x="375" y="520" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1lnkrx5_di" bpmnElement="Event_002h8ps">
         <dc:Bounds x="290" y="502" width="36" height="36" />
       </bpmndi:BPMNShape>
@@ -473,9 +463,171 @@
           <dc:Bounds x="359" y="465" width="82" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1khohx9_di" bpmnElement="Flow_1khohx9">
+        <di:waypoint x="326" y="520" />
+        <di:waypoint x="375" y="520" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1oe0aef_di" bpmnElement="Flow_1oe0aef">
+        <di:waypoint x="580" y="520" />
+        <di:waypoint x="642" y="520" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1eq00q6_di" bpmnElement="Flow_1eq00q6">
+        <di:waypoint x="425" y="520" />
+        <di:waypoint x="480" y="520" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="444" y="502" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06yz81p_di" bpmnElement="Flow_06yz81p">
+        <di:waypoint x="400" y="545" />
+        <di:waypoint x="400" y="630" />
+        <di:waypoint x="660" y="630" />
+        <di:waypoint x="660" y="538" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="412" y="553" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="TextAnnotation_15g9k3f_di" bpmnElement="TextAnnotation_15g9k3f">
         <dc:Bounds x="160" y="120" width="360" height="26" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_05n8qj8_di" bpmnElement="Activity_0caepsu" isExpanded="true">
+        <dc:Bounds x="245" y="690" width="790" height="250" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1oejvef_di" bpmnElement="TextAnnotation_1oejvef">
+        <dc:Bounds x="265" y="710" width="250" height="70" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_11h47hx_di" bpmnElement="Event_072g6mg">
+        <dc:Bounds x="285" y="832" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="273" y="875" width="61" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0u0vt45" bpmnElement="Activity_0wjyoge">
+        <dc:Bounds x="365" y="810" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1xi5jc4" bpmnElement="Activity_0x73wcr">
+        <dc:Bounds x="515" y="810" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0v48l92_di" bpmnElement="notify-others">
+        <dc:Bounds x="645" y="810" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0uy2zq2" bpmnElement="Activity_1aiu7sp">
+        <dc:Bounds x="795" y="810" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0hfv9hy_di" bpmnElement="Event_0hfv9hy">
+        <dc:Bounds x="947" y="832" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1b25zkd_di" bpmnElement="Association_1b25zkd">
+        <di:waypoint x="305" y="832" />
+        <di:waypoint x="310" y="780" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c2xzxq_di" bpmnElement="Flow_1c2xzxq">
+        <di:waypoint x="321" y="850" />
+        <di:waypoint x="365" y="850" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0laljwe_di" bpmnElement="Flow_0laljwe">
+        <di:waypoint x="465" y="850" />
+        <di:waypoint x="515" y="850" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0sjbp2b_di" bpmnElement="Flow_0sjbp2b">
+        <di:waypoint x="615" y="850" />
+        <di:waypoint x="645" y="850" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1g3i425_di" bpmnElement="Flow_1g3i425">
+        <di:waypoint x="745" y="850" />
+        <di:waypoint x="795" y="850" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ynyan2_di" bpmnElement="Flow_0ynyan2">
+        <di:waypoint x="895" y="850" />
+        <di:waypoint x="947" y="850" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ew46h4_di" bpmnElement="Flow_1ew46h4">
+        <di:waypoint x="248" y="187" />
+        <di:waypoint x="350" y="187" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1oxyoos_di" bpmnElement="Flow_1oxyoos">
+        <di:waypoint x="640" y="212" />
+        <di:waypoint x="640" y="300" />
+        <di:waypoint x="720" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1edl8wf_di" bpmnElement="Flow_1edl8wf">
+        <di:waypoint x="820" y="300" />
+        <di:waypoint x="900" y="300" />
+        <di:waypoint x="900" y="212" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0s1b66d_di" bpmnElement="Flow_0s1b66d">
+        <di:waypoint x="925" y="187" />
+        <di:waypoint x="975" y="187" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_05sub3t_di" bpmnElement="Flow_05sub3t">
+        <di:waypoint x="1340" y="187" />
+        <di:waypoint x="1380" y="187" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ttdn03_di" bpmnElement="Flow_0ttdn03">
+        <di:waypoint x="1560" y="212" />
+        <di:waypoint x="1560" y="320" />
+        <di:waypoint x="1660" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0zhm3wb_di" bpmnElement="Flow_0zhm3wb">
+        <di:waypoint x="1760" y="187" />
+        <di:waypoint x="1825" y="187" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1getqr6_di" bpmnElement="Flow_1getqr6">
+        <di:waypoint x="820" y="187" />
+        <di:waypoint x="875" y="187" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1epwomt_di" bpmnElement="Flow_1epwomt">
+        <di:waypoint x="1585" y="187" />
+        <di:waypoint x="1660" y="187" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_12eezq7_di" bpmnElement="Flow_12eezq7">
+        <di:waypoint x="545" y="187" />
+        <di:waypoint x="615" y="187" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="571" y="169" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1n61zbo_di" bpmnElement="Flow_1n61zbo">
+        <di:waypoint x="520" y="162" />
+        <di:waypoint x="520" y="100" />
+        <di:waypoint x="1000" y="100" />
+        <di:waypoint x="1000" y="160" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="762" y="83" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0fmnken_di" bpmnElement="Flow_0fmnken">
+        <di:waypoint x="1025" y="187" />
+        <di:waypoint x="1080" y="187" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_12ar9lm_di" bpmnElement="Flow_12ar9lm">
+        <di:waypoint x="450" y="187" />
+        <di:waypoint x="495" y="187" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ca8m5f_di" bpmnElement="Flow_1ca8m5f">
+        <di:waypoint x="665" y="187" />
+        <di:waypoint x="720" y="187" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0oxw9zk_di" bpmnElement="Flow_0oxw9zk">
+        <di:waypoint x="1180" y="187" />
+        <di:waypoint x="1240" y="187" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0vzb5ay_di" bpmnElement="Flow_0vzb5ay">
+        <di:waypoint x="1480" y="187" />
+        <di:waypoint x="1535" y="187" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1qzzlnv_di" bpmnElement="Flow_1qzzlnv">
+        <di:waypoint x="1760" y="320" />
+        <di:waypoint x="1850" y="320" />
+        <di:waypoint x="1850" y="212" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0v65v05_di" bpmnElement="Flow_0v65v05">
+        <di:waypoint x="1875" y="187" />
+        <di:waypoint x="1942" y="187" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Association_0uafnuq_di" bpmnElement="Association_0uafnuq">
         <di:waypoint x="224" y="170" />
         <di:waypoint x="216" y="146" />

--- a/src/main/resources/zeebe_release.bpmn
+++ b/src/main/resources/zeebe_release.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1sojgd1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.3.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1sojgd1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.3.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
   <bpmn:process id="zeebe-release-process" name="Zeebe release" isExecutable="true">
     <bpmn:extensionElements>
       <zeebe:userTaskForm id="userTaskForm_0uh0d7s">{
@@ -318,10 +318,6 @@
       <bpmn:sequenceFlow id="Flow_06yz81p" name="No" sourceRef="Gateway_0pprots" targetRef="Event_09hnipm" />
     </bpmn:subProcess>
     <bpmn:subProcess id="Activity_0caepsu" name="Release Candidate" triggeredByEvent="true">
-      <bpmn:startEvent id="Event_072g6mg" name="Built release candidate">
-        <bpmn:outgoing>Flow_1c2xzxq</bpmn:outgoing>
-        <bpmn:messageEventDefinition id="MessageEventDefinition_0qd3cau" messageRef="Message_36527rk" />
-      </bpmn:startEvent>
       <bpmn:userTask id="Activity_0wjyoge" name="Trigger release candidate">
         <bpmn:extensionElements>
           <zeebe:formDefinition formKey="camunda-forms:bpmn:UserTaskForm_0106sqk" />
@@ -368,6 +364,10 @@
         <bpmn:incoming>Flow_0ynyan2</bpmn:incoming>
       </bpmn:endEvent>
       <bpmn:sequenceFlow id="Flow_0ynyan2" sourceRef="Activity_1aiu7sp" targetRef="Event_0hfv9hy" />
+      <bpmn:startEvent id="Event_072g6mg" name="Built release candidate" isInterrupting="false">
+        <bpmn:outgoing>Flow_1c2xzxq</bpmn:outgoing>
+        <bpmn:messageEventDefinition id="MessageEventDefinition_0zmenc7" />
+      </bpmn:startEvent>
       <bpmn:textAnnotation id="TextAnnotation_1oejvef">
         <bpmn:text>correlationKey: release-branch-name
 messageName: rc</bpmn:text>
@@ -406,6 +406,7 @@ messageName: rc</bpmn:text>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1mxwnsr_di" bpmnElement="Activity_19s3dm7">
         <dc:Bounds x="1080" y="147" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1alb5n9_di" bpmnElement="trigger-release">
         <dc:Bounds x="1240" y="147" width="100" height="80" />
@@ -490,19 +491,13 @@ messageName: rc</bpmn:text>
       <bpmndi:BPMNShape id="TextAnnotation_15g9k3f_di" bpmnElement="TextAnnotation_15g9k3f">
         <dc:Bounds x="160" y="120" width="360" height="26" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_05n8qj8_di" bpmnElement="Activity_0caepsu" isExpanded="true">
+      <bpmndi:BPMNShape id="Activity_05n8qj8_di" bpmnElement="Activity_0caepsu" isExpanded="true" bioc:stroke="#1e88e5" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#1e88e5">
         <dc:Bounds x="245" y="690" width="790" height="250" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="TextAnnotation_1oejvef_di" bpmnElement="TextAnnotation_1oejvef">
         <dc:Bounds x="265" y="710" width="250" height="70" />
         <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_11h47hx_di" bpmnElement="Event_072g6mg">
-        <dc:Bounds x="285" y="832" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="273" y="875" width="61" height="27" />
-        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0u0vt45" bpmnElement="Activity_0wjyoge">
         <dc:Bounds x="365" y="810" width="100" height="80" />
@@ -519,6 +514,12 @@ messageName: rc</bpmn:text>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0hfv9hy_di" bpmnElement="Event_0hfv9hy">
         <dc:Bounds x="947" y="832" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1pp1hmf_di" bpmnElement="Event_072g6mg">
+        <dc:Bounds x="285" y="832" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="273" y="875" width="61" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Association_1b25zkd_di" bpmnElement="Association_1b25zkd">
         <di:waypoint x="305" y="832" />

--- a/src/main/resources/zeebe_release.bpmn
+++ b/src/main/resources/zeebe_release.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1sojgd1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.3.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1sojgd1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.3.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
   <bpmn:process id="zeebe-release-process" name="Zeebe release" isExecutable="true">
     <bpmn:extensionElements>
       <zeebe:userTaskForm id="userTaskForm_0uh0d7s">{
@@ -109,42 +109,6 @@
   "executionPlatform": "Camunda Cloud",
   "executionPlatformVersion": "1.2"
 }</zeebe:userTaskForm>
-      <zeebe:userTaskForm id="UserTaskForm_0106sqk">{
-  "schemaVersion": 2,
-  "components": [
-    {
-      "label": "Current release process",
-      "type": "textfield",
-      "id": "Field_0zdbd7q",
-      "key": "release_version"
-    },
-    {
-      "text": "# Run the release pipeline\n\nThe Zeebe release pipeline runs on the same Jenkins instance as the CI pipeline, [here](https://ci.zeebe.camunda.cloud/job/zeebe-release/).  The pipeline itself lives in the Zeebe repository, [here](https://github.com/camunda-cloud/zeebe/blob/develop/.ci/pipelines/release_zeebe.groovy). In short, it will build the release branch, stage and deploy Maven and Docker artifacts, tag the release, and update the version for the next development iteration. \n\n[Create a new build](https://ci.zeebe.camunda.cloud/job/zeebe-release/build?delay=0sec), and fill in the parameters accordingly.\n\n  \n**Alpha release**\n```\nRELEASE_VERSION: MAJOR.MINOR.0-ALPHA\nDEVELOPMENT_VERSION: MAJOR.MINOR.0-SNAPSHOT\nPUSH_CHANGES: true\nPUSH_DOCKER: true\nIS_LATEST: false\n```\n\n  \n**Patch release**\n\n&gt; **NOTE**: here the development version is MAJOR.MINOR.PATCH+1-SNAPSHOT. So if you have your release version is `1.2.1`, then the next development version will be `1.2.2-SNAPSHOT`.\n\n&gt; **NOTE**: if you are release a patch release for the latest minor release, then `IS_LATEST` should be set to `true`.\n\n```\nRELEASE_VERSION: MAJOR.MINOR.PATCH\nDEVELOPMENT_VERSION: MAJOR.MINOR.PATCH+1-SNAPSHOT\nPUSH_CHANGES: true\nPUSH_DOCKER: true\nIS_LATEST: false\n```\n\n  \n**Minor release**\n\n&gt; **NOTE**: here the development version is MAJOR.MINOR+1.0-SNAPSHOT. So if you have your release version is `1.2.0`, then the next development version will be `1.3.0-SNAPSHOT`.\n\n```\nRELEASE_VERSION: MAJOR.MINOR.0\nDEVELOPMENT_VERSION: MAJOR.MINOR+1.0-SNAPSHOT\nPUSH_CHANGES: true\nPUSH_DOCKER: true\nIS_LATEST: true\n```\n  \n  \nClick `Build` to start the release process, and wait until the pipeline finishes successfully.\n\nHints:\n- Sometimes the release process will fail. It's currently necessary to manually rollback the changes before restarting again. To roll back the changes, you will need to delete any tags that the job may have created (you can do so via the Github Web UI), and also drop the additional commits that the job added on the release branch, such that it's in the state it was before running the job. You may also have to drop the Maven artifacts on Maven central, [here](https://s01.oss.sonatype.org/).\n- If unsure about anything, ask the team and/or your tech lead.",
-      "type": "text",
-      "id": "Field_05xq34i"
-    }
-  ],
-  "type": "default",
-  "id": "Form_1ituz9d"
-}</zeebe:userTaskForm>
-      <zeebe:userTaskForm id="UserTaskForm_1fmei0t">{
-  "schemaVersion": 2,
-  "components": [
-    {
-      "label": "Current release process",
-      "type": "textfield",
-      "id": "Field_01aedoc",
-      "key": "release_version"
-    },
-    {
-      "text": "# Release the Maven artifacts\n\nOnce the pipeline was successfully finished, the Docker artifacts will already be available publicly. We now have to release the Maven central ones.\n\n1. Go to [Maven Central](https://s01.oss.sonatype.org/) and login using the shared `Maven Central` credentials for login `camundabpm` found in [Keeper](https://keepersecurity.eu/vault/) under `Shared-Engineering - Zeebe`. \n2. On the left side, click on the 'Staging Repositories' link.\n3. After it has been loaded, scroll down to the bottom of the list. You should find the relevant Zeebe staging repositories there.\n4. Mark the repository you want to release, which should be one for zeebe.\n\n&gt; io.camunda:zeebe*\n\n\n5. Click on 'Release' at the menu on top of the list. A window will pop up were you can enter a description but it is not necessary. Activate 'Drop repository after release automatically'. Then proceed.\n6. Done.",
-      "type": "text",
-      "id": "Field_10avz1w"
-    }
-  ],
-  "type": "default",
-  "id": "Form_1tx0oak"
-}</zeebe:userTaskForm>
     </bpmn:extensionElements>
     <bpmn:startEvent id="StartEvent_1" name="Release started">
       <bpmn:extensionElements>
@@ -159,11 +123,13 @@
       <bpmn:incoming>Flow_12eezq7</bpmn:incoming>
       <bpmn:outgoing>Flow_1oxyoos</bpmn:outgoing>
       <bpmn:outgoing>Flow_1ca8m5f</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0c32sfk</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:sequenceFlow id="Flow_1oxyoos" sourceRef="Gateway_113spke" targetRef="collect-release-notes" />
     <bpmn:parallelGateway id="Gateway_038v8ud">
       <bpmn:incoming>Flow_1edl8wf</bpmn:incoming>
       <bpmn:incoming>Flow_1getqr6</bpmn:incoming>
+      <bpmn:incoming>Flow_1t4de6j</bpmn:incoming>
       <bpmn:outgoing>Flow_0s1b66d</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:sequenceFlow id="Flow_1edl8wf" sourceRef="collect-release-notes" targetRef="Gateway_038v8ud" />
@@ -254,7 +220,7 @@
     <bpmn:sequenceFlow id="Flow_12eezq7" name="Yes" sourceRef="Gateway_1afx4hl" targetRef="Gateway_113spke">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">= release_type = "major" or release_type = "minor"</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1n61zbo" name="No" sourceRef="Gateway_1afx4hl" targetRef="Gateway_15n27wl" />
+    <bpmn:sequenceFlow id="Flow_1n61zbo" name="No - Alpha release" sourceRef="Gateway_1afx4hl" targetRef="Gateway_15n27wl" />
     <bpmn:exclusiveGateway id="Gateway_15n27wl">
       <bpmn:incoming>Flow_0s1b66d</bpmn:incoming>
       <bpmn:incoming>Flow_1n61zbo</bpmn:incoming>
@@ -318,66 +284,45 @@
       <bpmn:sequenceFlow id="Flow_06yz81p" name="No" sourceRef="Gateway_0pprots" targetRef="Event_09hnipm" />
     </bpmn:subProcess>
     <bpmn:subProcess id="Activity_0caepsu" name="Release Candidate" triggeredByEvent="true">
-      <bpmn:userTask id="Activity_0wjyoge" name="Trigger release candidate">
-        <bpmn:extensionElements>
-          <zeebe:formDefinition formKey="camunda-forms:bpmn:UserTaskForm_0106sqk" />
-        </bpmn:extensionElements>
-        <bpmn:incoming>Flow_1c2xzxq</bpmn:incoming>
-        <bpmn:outgoing>Flow_0laljwe</bpmn:outgoing>
-      </bpmn:userTask>
-      <bpmn:sequenceFlow id="Flow_1c2xzxq" sourceRef="Event_072g6mg" targetRef="Activity_0wjyoge" />
-      <bpmn:userTask id="Activity_0x73wcr" name="Release on Maven Central">
-        <bpmn:extensionElements>
-          <zeebe:formDefinition formKey="camunda-forms:bpmn:UserTaskForm_1fmei0t" />
-        </bpmn:extensionElements>
-        <bpmn:incoming>Flow_0laljwe</bpmn:incoming>
-        <bpmn:outgoing>Flow_0sjbp2b</bpmn:outgoing>
-      </bpmn:userTask>
-      <bpmn:sequenceFlow id="Flow_0laljwe" sourceRef="Activity_0wjyoge" targetRef="Activity_0x73wcr" />
-      <bpmn:serviceTask id="notify-others" name="Notify other teams" zeebe:modelerTemplate="io.camunda.connectors.Slack.v1" zeebe:modelerTemplateIcon="data:image/svg+xml;utf8,%3Csvg%20width%3D%2218%22%20height%3D%2218%22%20%20viewBox%3D%220%200%20127%20127%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%3Cpath%20d%3D%22M27.2%2080c0%207.3-5.9%2013.2-13.2%2013.2C6.7%2093.2.8%2087.3.8%2080c0-7.3%205.9-13.2%2013.2-13.2h13.2V80zm6.6%200c0-7.3%205.9-13.2%2013.2-13.2%207.3%200%2013.2%205.9%2013.2%2013.2v33c0%207.3-5.9%2013.2-13.2%2013.2-7.3%200-13.2-5.9-13.2-13.2V80z%22%20fill%3D%22%23E01E5A%22%2F%3E%0A%20%20%3Cpath%20d%3D%22M47%2027c-7.3%200-13.2-5.9-13.2-13.2C33.8%206.5%2039.7.6%2047%20.6c7.3%200%2013.2%205.9%2013.2%2013.2V27H47zm0%206.7c7.3%200%2013.2%205.9%2013.2%2013.2%200%207.3-5.9%2013.2-13.2%2013.2H13.9C6.6%2060.1.7%2054.2.7%2046.9c0-7.3%205.9-13.2%2013.2-13.2H47z%22%20fill%3D%22%2336C5F0%22%2F%3E%0A%20%20%3Cpath%20d%3D%22M99.9%2046.9c0-7.3%205.9-13.2%2013.2-13.2%207.3%200%2013.2%205.9%2013.2%2013.2%200%207.3-5.9%2013.2-13.2%2013.2H99.9V46.9zm-6.6%200c0%207.3-5.9%2013.2-13.2%2013.2-7.3%200-13.2-5.9-13.2-13.2V13.8C66.9%206.5%2072.8.6%2080.1.6c7.3%200%2013.2%205.9%2013.2%2013.2v33.1z%22%20fill%3D%22%232EB67D%22%2F%3E%0A%20%20%3Cpath%20d%3D%22M80.1%2099.8c7.3%200%2013.2%205.9%2013.2%2013.2%200%207.3-5.9%2013.2-13.2%2013.2-7.3%200-13.2-5.9-13.2-13.2V99.8h13.2zm0-6.6c-7.3%200-13.2-5.9-13.2-13.2%200-7.3%205.9-13.2%2013.2-13.2h33.1c7.3%200%2013.2%205.9%2013.2%2013.2%200%207.3-5.9%2013.2-13.2%2013.2H80.1z%22%20fill%3D%22%23ECB22E%22%2F%3E%0A%3C%2Fsvg%3E%0A">
-        <bpmn:extensionElements>
-          <zeebe:taskDefinition type="io.camunda:slack:1" />
-          <zeebe:ioMapping>
-            <zeebe:input source="chat.postMessage" target="method" />
-            <zeebe:input source="secrets.SLACK_OAUTH_TOKEN" target="token" />
-            <zeebe:input source="#c8-release-announcements" target="data.channel" />
-            <zeebe:input source="= &#34;Hi :wave: team! There is a new Zeebe version &#34; + release_version + &#34; available that you can test against.&#34;" target="data.text" />
-          </zeebe:ioMapping>
-          <zeebe:taskHeaders>
-            <zeebe:header key="resultVariable" />
-            <zeebe:header key="resultExpression" />
-          </zeebe:taskHeaders>
-        </bpmn:extensionElements>
-        <bpmn:incoming>Flow_0sjbp2b</bpmn:incoming>
-        <bpmn:outgoing>Flow_1g3i425</bpmn:outgoing>
-      </bpmn:serviceTask>
-      <bpmn:sequenceFlow id="Flow_0sjbp2b" sourceRef="Activity_0x73wcr" targetRef="notify-others" />
-      <bpmn:callActivity id="Activity_1aiu7sp" name="Release Zeebe process test">
-        <bpmn:extensionElements>
-          <zeebe:calledElement processId="zeebe-process-test-release" propagateAllChildVariables="false" />
-        </bpmn:extensionElements>
-        <bpmn:incoming>Flow_1g3i425</bpmn:incoming>
-        <bpmn:outgoing>Flow_0ynyan2</bpmn:outgoing>
-      </bpmn:callActivity>
-      <bpmn:sequenceFlow id="Flow_1g3i425" sourceRef="notify-others" targetRef="Activity_1aiu7sp" />
       <bpmn:endEvent id="Event_0hfv9hy">
-        <bpmn:incoming>Flow_0ynyan2</bpmn:incoming>
+        <bpmn:incoming>Flow_1a33fza</bpmn:incoming>
       </bpmn:endEvent>
-      <bpmn:sequenceFlow id="Flow_0ynyan2" sourceRef="Activity_1aiu7sp" targetRef="Event_0hfv9hy" />
-      <bpmn:startEvent id="Event_072g6mg" name="Built release candidate" isInterrupting="false">
-        <bpmn:outgoing>Flow_1c2xzxq</bpmn:outgoing>
+      <bpmn:startEvent id="Event_072g6mg" name="Build release candidate" isInterrupting="false">
+        <bpmn:outgoing>Flow_0laqkqg</bpmn:outgoing>
         <bpmn:messageEventDefinition id="MessageEventDefinition_0zmenc7" />
       </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_0laqkqg" sourceRef="Event_072g6mg" targetRef="Activity_1wtaxv3" />
+      <bpmn:callActivity id="Activity_1wtaxv3" name="Build release candidate">
+        <bpmn:extensionElements>
+          <zeebe:calledElement processId="build-release-candidate" propagateAllChildVariables="false" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_0laqkqg</bpmn:incoming>
+        <bpmn:outgoing>Flow_1a33fza</bpmn:outgoing>
+      </bpmn:callActivity>
+      <bpmn:sequenceFlow id="Flow_1a33fza" sourceRef="Activity_1wtaxv3" targetRef="Event_0hfv9hy" />
       <bpmn:textAnnotation id="TextAnnotation_1oejvef">
         <bpmn:text>correlationKey: release-branch-name
 messageName: rc</bpmn:text>
       </bpmn:textAnnotation>
       <bpmn:association id="Association_1b25zkd" sourceRef="Event_072g6mg" targetRef="TextAnnotation_1oejvef" />
     </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_0c32sfk" sourceRef="Gateway_113spke" targetRef="Activity_175is1m" />
+    <bpmn:callActivity id="Activity_175is1m" name="Build release candidate">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="build-release-candidate" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0c32sfk</bpmn:incoming>
+      <bpmn:outgoing>Flow_1t4de6j</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_1t4de6j" sourceRef="Activity_175is1m" targetRef="Gateway_038v8ud" />
     <bpmn:textAnnotation id="TextAnnotation_15g9k3f">
       <bpmn:text>req: release_version: string</bpmn:text>
     </bpmn:textAnnotation>
     <bpmn:association id="Association_0uafnuq" sourceRef="StartEvent_1" targetRef="TextAnnotation_15g9k3f" />
+    <bpmn:textAnnotation id="TextAnnotation_149oh6t">
+      <bpmn:text>Used by other teams to test against and by the e2e tests.</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_10w5l9m" sourceRef="Activity_175is1m" targetRef="TextAnnotation_149oh6t" />
   </bpmn:process>
   <bpmn:message id="Message_36527rk" name="rc">
     <bpmn:extensionElements>
@@ -386,6 +331,10 @@ messageName: rc</bpmn:text>
   </bpmn:message>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="zeebe-release-process">
+      <bpmndi:BPMNShape id="TextAnnotation_149oh6t_di" bpmnElement="TextAnnotation_149oh6t">
+        <dc:Bounds x="840" y="460" width="99.99156545209178" height="70.17543859649123" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="212" y="169" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -444,106 +393,93 @@ messageName: rc</bpmn:text>
       <bpmndi:BPMNShape id="Gateway_1ibg4oe_di" bpmnElement="Gateway_1wq2h17">
         <dc:Bounds x="1825" y="162" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0ofy7ul_di" bpmnElement="Activity_0lywzc8" isExpanded="true">
-        <dc:Bounds x="250" y="420" width="480" height="240" />
+      <bpmndi:BPMNShape id="Activity_0yob6f4_di" bpmnElement="Activity_175is1m">
+        <dc:Bounds x="720" y="370" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1lnkrx5_di" bpmnElement="Event_002h8ps">
-        <dc:Bounds x="290" y="502" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_015rjku_di" bpmnElement="Activity_1pj3quo">
-        <dc:Bounds x="480" y="480" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_09hnipm_di" bpmnElement="Event_09hnipm">
-        <dc:Bounds x="642" y="502" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0pprots_di" bpmnElement="Gateway_0pprots" isMarkerVisible="true">
-        <dc:Bounds x="375" y="495" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="359" y="465" width="82" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1khohx9_di" bpmnElement="Flow_1khohx9">
-        <di:waypoint x="326" y="520" />
-        <di:waypoint x="375" y="520" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1oe0aef_di" bpmnElement="Flow_1oe0aef">
-        <di:waypoint x="580" y="520" />
-        <di:waypoint x="642" y="520" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1eq00q6_di" bpmnElement="Flow_1eq00q6">
-        <di:waypoint x="425" y="520" />
-        <di:waypoint x="480" y="520" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="444" y="502" width="18" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_06yz81p_di" bpmnElement="Flow_06yz81p">
-        <di:waypoint x="400" y="545" />
-        <di:waypoint x="400" y="630" />
-        <di:waypoint x="660" y="630" />
-        <di:waypoint x="660" y="538" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="412" y="553" width="15" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="TextAnnotation_15g9k3f_di" bpmnElement="TextAnnotation_15g9k3f">
         <dc:Bounds x="160" y="120" width="360" height="26" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_05n8qj8_di" bpmnElement="Activity_0caepsu" isExpanded="true" bioc:stroke="#1e88e5" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#1e88e5">
-        <dc:Bounds x="245" y="690" width="790" height="250" />
+      <bpmndi:BPMNShape id="Activity_05n8qj8_di" bpmnElement="Activity_0caepsu" isExpanded="true">
+        <dc:Bounds x="247" y="800" width="485" height="240" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="TextAnnotation_1oejvef_di" bpmnElement="TextAnnotation_1oejvef">
-        <dc:Bounds x="265" y="710" width="250" height="70" />
+        <dc:Bounds x="267" y="820" width="250" height="70" />
         <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0u0vt45" bpmnElement="Activity_0wjyoge">
-        <dc:Bounds x="365" y="810" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1xi5jc4" bpmnElement="Activity_0x73wcr">
-        <dc:Bounds x="515" y="810" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0v48l92_di" bpmnElement="notify-others">
-        <dc:Bounds x="645" y="810" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0uy2zq2" bpmnElement="Activity_1aiu7sp">
-        <dc:Bounds x="795" y="810" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0hfv9hy_di" bpmnElement="Event_0hfv9hy">
-        <dc:Bounds x="947" y="832" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1pp1hmf_di" bpmnElement="Event_072g6mg">
-        <dc:Bounds x="285" y="832" width="36" height="36" />
+        <dc:Bounds x="287" y="942" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="273" y="875" width="61" height="27" />
+          <dc:Bounds x="274" y="985" width="64" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0hfv9hy_di" bpmnElement="Event_0hfv9hy">
+        <dc:Bounds x="634" y="942" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_02565vq_di" bpmnElement="Activity_1wtaxv3">
+        <dc:Bounds x="432" y="920" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Association_1b25zkd_di" bpmnElement="Association_1b25zkd">
-        <di:waypoint x="305" y="832" />
-        <di:waypoint x="310" y="780" />
+        <di:waypoint x="307" y="942" />
+        <di:waypoint x="312" y="890" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1c2xzxq_di" bpmnElement="Flow_1c2xzxq">
-        <di:waypoint x="321" y="850" />
-        <di:waypoint x="365" y="850" />
+      <bpmndi:BPMNEdge id="Flow_0laqkqg_di" bpmnElement="Flow_0laqkqg">
+        <di:waypoint x="323" y="960" />
+        <di:waypoint x="432" y="960" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0laljwe_di" bpmnElement="Flow_0laljwe">
-        <di:waypoint x="465" y="850" />
-        <di:waypoint x="515" y="850" />
+      <bpmndi:BPMNEdge id="Flow_1a33fza_di" bpmnElement="Flow_1a33fza">
+        <di:waypoint x="532" y="960" />
+        <di:waypoint x="634" y="960" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0sjbp2b_di" bpmnElement="Flow_0sjbp2b">
-        <di:waypoint x="615" y="850" />
-        <di:waypoint x="645" y="850" />
+      <bpmndi:BPMNShape id="Activity_0ofy7ul_di" bpmnElement="Activity_0lywzc8" isExpanded="true">
+        <dc:Bounds x="250" y="550" width="480" height="240" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1lnkrx5_di" bpmnElement="Event_002h8ps">
+        <dc:Bounds x="290" y="632" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_015rjku_di" bpmnElement="Activity_1pj3quo">
+        <dc:Bounds x="480" y="610" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_09hnipm_di" bpmnElement="Event_09hnipm">
+        <dc:Bounds x="642" y="632" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0pprots_di" bpmnElement="Gateway_0pprots" isMarkerVisible="true">
+        <dc:Bounds x="375" y="625" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="359" y="595" width="82" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1khohx9_di" bpmnElement="Flow_1khohx9">
+        <di:waypoint x="326" y="650" />
+        <di:waypoint x="375" y="650" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1g3i425_di" bpmnElement="Flow_1g3i425">
-        <di:waypoint x="745" y="850" />
-        <di:waypoint x="795" y="850" />
+      <bpmndi:BPMNEdge id="Flow_1eq00q6_di" bpmnElement="Flow_1eq00q6">
+        <di:waypoint x="425" y="650" />
+        <di:waypoint x="480" y="650" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="444" y="632" width="19" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ynyan2_di" bpmnElement="Flow_0ynyan2">
-        <di:waypoint x="895" y="850" />
-        <di:waypoint x="947" y="850" />
+      <bpmndi:BPMNEdge id="Flow_1oe0aef_di" bpmnElement="Flow_1oe0aef">
+        <di:waypoint x="580" y="650" />
+        <di:waypoint x="642" y="650" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06yz81p_di" bpmnElement="Flow_06yz81p">
+        <di:waypoint x="400" y="675" />
+        <di:waypoint x="400" y="760" />
+        <di:waypoint x="660" y="760" />
+        <di:waypoint x="660" y="668" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="412" y="683" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_10w5l9m_di" bpmnElement="Association_10w5l9m">
+        <di:waypoint x="820" y="437" />
+        <di:waypoint x="862" y="460" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ew46h4_di" bpmnElement="Flow_1ew46h4">
         <di:waypoint x="248" y="187" />
@@ -597,7 +533,7 @@ messageName: rc</bpmn:text>
         <di:waypoint x="1000" y="100" />
         <di:waypoint x="1000" y="160" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="762" y="83" width="15" height="14" />
+          <dc:Bounds x="733" y="66" width="74" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0fmnken_di" bpmnElement="Flow_0fmnken">
@@ -632,6 +568,16 @@ messageName: rc</bpmn:text>
       <bpmndi:BPMNEdge id="Association_0uafnuq_di" bpmnElement="Association_0uafnuq">
         <di:waypoint x="224" y="170" />
         <di:waypoint x="216" y="146" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0c32sfk_di" bpmnElement="Flow_0c32sfk">
+        <di:waypoint x="640" y="212" />
+        <di:waypoint x="640" y="410" />
+        <di:waypoint x="720" y="410" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1t4de6j_di" bpmnElement="Flow_1t4de6j">
+        <di:waypoint x="820" y="410" />
+        <di:waypoint x="900" y="410" />
+        <di:waypoint x="900" y="212" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
I added another event subprocess to allow to build a release candidate. This helps to not find all information by hand, but with that we can use our existing tooling and information we have in the process.


![zeebe_release](https://user-images.githubusercontent.com/2758593/192475892-b7fd05f7-312f-423b-b13a-18f6fcb3930d.png)

